### PR TITLE
Don't copy vendors.

### DIFF
--- a/deployment/deploy.rb
+++ b/deployment/deploy.rb
@@ -5,7 +5,6 @@ set  :keep_releases,  3
 
 # Composer configuration
 set :use_composer, true
-set :copy_vendors, true
 
 # Git configuration
 set :scm, :git


### PR DESCRIPTION
It only slows down the installation. Composer fetches all dependencies
from cache. This is faster then copying the vendors and letting composer
compare the copied vendors with the dependencies that should be
installed.