### PR TITLE
Integrate doctrine migrations bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Add a user with
 
 You can now go to <your domain>/en/users/login and login with the given user.
 
+### Configure migrations
+
+When you start you should initialize the migrations:
+
+    app/console doctrine:migrations:status
+
 ## Error handling
 
 Enable the FrameworkErrorBundle in the kernel, just add it in production mode, as this bundle
@@ -46,5 +52,6 @@ See [https://github.com/phiamo/MopaBootstrapBundle](https://github.com/phiamo/Mo
 
 * [Using Grunt](./src/SumoCoders/FrameworkCoreBundle/Resources/doc/grunt.md)
 * [Deployment](./src/SumoCoders/FrameworkCoreBundle/Resources/doc/deployment.md)
+* [Database Changes/Migrations](./src/SumoCoders/FrameworkCoreBundle/Resources/doc/migrations.md)
 * [Adding items into the menu/navigation](./src/SumoCoders/FrameworkCoreBundle/Resources/doc/menu.md)
 * [Known issues](./src/SumCoders/FrameworkCoreBundle/Resources/doc/issues.md)

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -15,6 +15,7 @@ class AppKernel extends Kernel
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Symfony\Bundle\AsseticBundle\AsseticBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
 
             new JMS\I18nRoutingBundle\JMSI18nRoutingBundle(),

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,8 @@
         "symfony/framework-bundle": "~2.6",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
+        "doctrine/migrations": "1.0.*@dev",
+        "doctrine/doctrine-migrations-bundle": "2.1.*@dev",
         "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.6",
         "symfony/swiftmailer-bundle": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/framework-bundle": "~2.6",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
-        "doctrine/migrations": "1.0.*@dev",
+        "doctrine/migrations": "1.0.x-dev",
         "doctrine/doctrine-migrations-bundle": "2.1.*@dev",
         "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "87e2c5c0cdcc99018b6580df3763fd65",
+    "hash": "4154686c4bc4b72af353a6e4191429e1",
     "packages": [
         {
             "name": "airbrake/airbrake-php",
@@ -567,6 +567,65 @@
             "time": "2014-11-28 09:43:36"
         },
         {
+            "name": "doctrine/doctrine-migrations-bundle",
+            "version": "dev-master",
+            "target-dir": "Doctrine/Bundle/MigrationsBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineMigrationsBundle.git",
+                "reference": "6a1bd731dbdd4ad952a3b246a8f38c9c12f52e62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineMigrationsBundle/zipball/6a1bd731dbdd4ad952a3b246a8f38c9c12f52e62",
+                "reference": "6a1bd731dbdd4ad952a3b246a8f38c9c12f52e62",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/doctrine-bundle": "~1.0",
+                "doctrine/migrations": "~1.0@dev",
+                "php": ">=5.3.2",
+                "symfony/framework-bundle": "~2.1"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Bundle\\MigrationsBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "http://www.doctrine-project.org"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony DoctrineMigrationsBundle",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "dbal",
+                "migrations",
+                "schema"
+            ],
+            "time": "2015-02-16 13:24:46"
+        },
+        {
             "name": "doctrine/inflector",
             "version": "v1.0.1",
             "source": {
@@ -686,6 +745,61 @@
                 "parser"
             ],
             "time": "2014-09-09 13:34:57"
+        },
+        {
+            "name": "doctrine/migrations",
+            "version": "v1.0-ALPHA1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/migrations.git",
+                "reference": "b38ddb190ec78d389b2c2de838b2a4d646ad1ce2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/b38ddb190ec78d389b2c2de838b2a4d646ad1ce2",
+                "reference": "b38ddb190ec78d389b2c2de838b2a4d646ad1ce2",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": ">=2.0,<2.5.x-dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "symfony/console": "2.*",
+                "symfony/yaml": "2.*"
+            },
+            "suggest": {
+                "symfony/console": "to run the migration from the console"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\Migrations": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                }
+            ],
+            "description": "Database Schema migrations using Doctrine DBAL",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "migrations"
+            ],
+            "time": "2012-10-05 11:15:13"
         },
         {
             "name": "doctrine/orm",
@@ -3596,6 +3710,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "doctrine/migrations": 20,
+        "doctrine/doctrine-migrations-bundle": 20,
         "friendsofsymfony/user-bundle": 20,
         "mopa/bootstrap-bundle": 20,
         "knplabs/knp-menu-bundle": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4154686c4bc4b72af353a6e4191429e1",
+    "hash": "39cbb97ea9ba0cea777ca3bfbb79bf0b",
     "packages": [
         {
             "name": "airbrake/airbrake-php",
@@ -748,20 +748,20 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "v1.0-ALPHA1",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "b38ddb190ec78d389b2c2de838b2a4d646ad1ce2"
+                "reference": "312fb5939d5b9dbd66e515374533933e7c5cc8a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/b38ddb190ec78d389b2c2de838b2a4d646ad1ce2",
-                "reference": "b38ddb190ec78d389b2c2de838b2a4d646ad1ce2",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/312fb5939d5b9dbd66e515374533933e7c5cc8a6",
+                "reference": "312fb5939d5b9dbd66e515374533933e7c5cc8a6",
                 "shasum": ""
             },
             "require": {
-                "doctrine/dbal": ">=2.0,<2.5.x-dev",
+                "doctrine/dbal": "~2.0",
                 "php": ">=5.3.2"
             },
             "require-dev": {
@@ -772,6 +772,11 @@
                 "symfony/console": "to run the migration from the console"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Doctrine\\DBAL\\Migrations": "lib"
@@ -779,18 +784,16 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL"
+                "LGPL-2.1"
             ],
             "authors": [
                 {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com",
-                    "homepage": "http://www.jwage.com/",
-                    "role": "Creator"
-                },
-                {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
                 }
             ],
             "description": "Database Schema migrations using Doctrine DBAL",
@@ -799,7 +802,7 @@
                 "database",
                 "migrations"
             ],
-            "time": "2012-10-05 11:15:13"
+            "time": "2015-03-02 18:28:52"
         },
         {
             "name": "doctrine/orm",

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/config/config.yml
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/config/config.yml
@@ -80,6 +80,12 @@ doctrine:
     auto_generate_proxy_classes: "%kernel.debug%"
     auto_mapping: true
 
+doctrine_migrations:
+    dir_name: %kernel.root_dir%/migrations
+    namespace: SumoCodersFramework\Migrations
+    table_name: migration_versions
+    name: Application Migrations
+
 # I18n Configuration
 jms_i18n_routing:
   default_locale: "%locale%"

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/doc/migrations.md
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/doc/migrations.md
@@ -1,0 +1,19 @@
+# Changing the database
+
+While developing you sometimes need to change the database. But to be able to 
+change the database on the server while deploying instead of doing these 
+changes manually we will use migrations.
+
+Migrations in the framework are handled by the [DoctrineMigrationsBundle](http://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html).
+
+## Usage
+
+Basically it is simple. The only thing you have to do when you need to change 
+the database structure is to change the annotation/configuration/... and run:
+ 
+    app/console doctrine:migrations:diff
+    
+This will generate a migration-class which you can commit along your changes.
+Of course you will need to run the migration to update your own database:
+
+    app/console doctrine:migration:migrate


### PR DESCRIPTION
While developing you sometimes need to change the database. But to be able to 
change the database on the server while deploying instead of doing these 
changes manually we will use migrations.

Migrations in the framework are handled by the [DoctrineMigrationsBundle](http://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html).

## Usage

Basically it is simple. The only thing you have to do when you need to change 
the database structure is to change the annotation/configuration/... and run:
 
    app/console doctrine:migrations:diff
    
This will generate a migration-class which you can commit along your changes.
Of course you will need to run the migration to update your own database:

    app/console doctrine:migration:migrate

This Pull Request will fix https://github.com/sumocoders/Framework/issues/24
