### PR TITLE
Get jsdata from the request when parsing into the template.

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/config/config.yml
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/config/config.yml
@@ -4,8 +4,8 @@ services:
     arguments: [%fallbacks%]
   framework.jsdata:
     class: SumoCoders\FrameworkCoreBundle\Service\JsData
-    calls:
-      - [setRequestStack, ["@request_stack"]]
+    arguments:
+      - "@request_stack"
   framework.menu_builder:
     class: SumoCoders\FrameworkCoreBundle\Menu\MenuBuilder
     calls:

--- a/src/SumoCoders/FrameworkCoreBundle/Service/JsData.php
+++ b/src/SumoCoders/FrameworkCoreBundle/Service/JsData.php
@@ -20,7 +20,7 @@ class JsData extends ParameterBag
     /**
      * @param RequestStack $requestStack
      */
-    public function setRequestStack(RequestStack $requestStack)
+    public function __construct(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
     }

--- a/src/SumoCoders/FrameworkCoreBundle/Service/JsData.php
+++ b/src/SumoCoders/FrameworkCoreBundle/Service/JsData.php
@@ -23,7 +23,6 @@ class JsData extends ParameterBag
     public function setRequestStack(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
-        $this->handleRequestStack();
     }
 
     /**
@@ -49,6 +48,8 @@ class JsData extends ParameterBag
      */
     public function __toString()
     {
+        $this->handleRequestStack();
+
         return json_encode($this->all());
     }
 }

--- a/src/SumoCoders/FrameworkCoreBundle/Tests/Service/JsDataTest.php
+++ b/src/SumoCoders/FrameworkCoreBundle/Tests/Service/JsDataTest.php
@@ -16,7 +16,7 @@ class JsDataTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->jsData = new JsData();
+        $this->jsData = new JsData($this->getRequestStack());
     }
 
     /**
@@ -54,7 +54,8 @@ class JsDataTest extends \PHPUnit_Framework_TestCase
      */
     public function testGet()
     {
-        $this->jsData->setRequestStack($this->getRequestStack());
+        // request is only parsed when fetching the data from the javascript
+        (string) $this->jsData;
         $this->assertEquals('nl', $this->jsData->get('request[locale]', null, true));
     }
 
@@ -63,16 +64,7 @@ class JsDataTest extends \PHPUnit_Framework_TestCase
      */
     public function testToString()
     {
-        $data = array();
         $var = (string) $this->jsData;
-        $this->assertEquals(json_encode($data), $var);
-
-        $request = new \stdClass();
-        $request->locale = 'nl';
-        $data = new \stdClass();
-        $data->request = $request;
-        $this->jsData->setRequestStack($this->getRequestStack());
-        $var = (string) $this->jsData;
-        $this->assertEquals(json_encode($data), $var);
+        $this->assertEquals('{"request":{"locale":"nl"}}', $var);
     }
 }


### PR DESCRIPTION
This makes sure we are fetching data from the latest request, so all
needed data (like the locale) is filled in.
It also makes sure the code isn't executed when jsData isn't parsed into
the template.