### PR TITLE
Fix twig tags in erb file.

### DIFF
--- a/deployment/maintenance.erb
+++ b/deployment/maintenance.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <!--[if IE]><![endif]-->
     <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"><![endif]-->
-    <title>{% block title %}{{ status_code }}: {{ status_text }}{% endblock %}</title>
+    <title>Down for <%= reason ? reason : "maintenance" %></title>
     <meta name="robots" content="noindex, nofollow">
     <meta name="author" content="SumoCoders">
     <link rel="shortcut icon" href="/favicon.ico">


### PR DESCRIPTION
The title tag on the maintenance page looked strange because of unrecognised twig tags. These erb style tags should fix this.