### PR TITLE
Only load datepickers if the JS is available.

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/coffee/framework.form.coffee
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/coffee/framework.form.coffee
@@ -86,6 +86,8 @@ class Form
     )
 
   _dateFields: ->
+    return if (!$.isFunction($.fn.datepicker))
+
     $.datepicker.setDefaults @_dateFieldOptions
 
     $('[data-date-type] input[type="text"]', @form).each((i, el) =>


### PR DESCRIPTION
This prevents JavaScript errors on our login page, where the datepicker
javascript is (and shouldn't be) available.