### PR TITLE
Add jQuery UI to empty template

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/views/empty.html.twig
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/views/empty.html.twig
@@ -45,6 +45,7 @@
 
         {% javascripts
             'assets/vendor/jquery/dist/jquery.min.js'
+            'assets/vendor/jquery-ui/jquery-ui.min.js'
             'assets/vendor/bootstrap/dist/js/bootstrap.min.js'
             'assets/vendor/modernizr/modernizr.js'
             'assets/vendor/respond/dest/respond.min.js'


### PR DESCRIPTION
Pages which use the empty template show an error, because they can't call the setDefault() method on the datepicker, which is loaded through jQuery UI.