### PR TITLE
Avoid database access during assetic dump.

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -10,6 +10,7 @@ parameters:
     database_name:
     database_user:
     database_password:
+    database_version: 5.5
 
     # Mail configuration
     mailer_transport: mail

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/config/config.yml
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/config/config.yml
@@ -49,6 +49,7 @@ doctrine:
     user:     "%database_user%"
     password: "%database_password%"
     charset:  UTF8
+    server_version: "%database_version%"
 
   orm:
     auto_generate_proxy_classes: "%kernel.debug%"


### PR DESCRIPTION
When doing an assetic dump, assetic will go trough all the templates and
compile all the assets.

Our framework contains some twig extensions that have our database as a
dependency (for example our settings mechanism). When accessing our
templates, this means our database needs to have all it's needed
configuration.

When Doctrine (DBAL) is instantiated, some variables need to be known.
One of them is the version of MySQL you are running (because this is
needed to make some functionality work). If it's not provided in the
config, doctrine will do a call to the database to fetch this version.

This commit makes sure this is not needed anymore. This means we can do
assetic:dump without the need of having a working database connection.

See https://github.com/kriswallsmith/assetic/issues/681 for more info.