### PR TITLE
Allow extra sass files to be processed.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -192,7 +192,7 @@ gulp.task('sass:generate_css', ['sass:centralise_sass_files', 'icons'], function
 
   return gulp.src(
       [
-        config.temporaryDir + '/sass/style.scss'
+        config.temporaryDir + '/sass/*.scss'
       ]
   )
       .pipe(sass({


### PR DESCRIPTION
Right now, only our style.scss file was converted to a css file. This change will allow other files to be processed as well.