### PR TITLE
Fix generated routes. Fixes #79

### DIFF
--- a/app/Resources/SensioGeneratorBundle/skeleton/crud/actions/edit.php.twig
+++ b/app/Resources/SensioGeneratorBundle/skeleton/crud/actions/edit.php.twig
@@ -3,7 +3,8 @@
 {% set niceBundleName = bundle|replace({'Bundle': ''})|lower %}
 {% set niceEntityName = entity|lower %}
 {% set niceEntityNamePlural = entity|lower ~ 's' %}
-{% set baseRoute = '%1$s_%2$s'|format(niceBundleName, niceEntityName) %}
+{% set niceNamespace = bundle|replace({'/': '_'})|lower %}
+{% set baseRoute = '%1$s_%2$s'|format(niceNamespace, niceEntityName) %}
 
 {% block phpdoc_method_header %}
      * Displays a form to edit an existing {{ entity }} entity.


### PR DESCRIPTION
The shortbundle name was used instead of a version containing an
underscore. For a Sumocoders\TestBundle, this resulted in
sumocoderstestbundle_entity_action instead of
sumocoders_testbundle_entity_action.