### PR TITLE
Don't run CI on hhvm-nightly anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,10 @@ matrix:
     - php: 7
     - php: nightly
     - php: hhvm
-    - php: hhvm-nightly
   allow_failures:
     - php: 7
     - php: nightly
     - php: hhvm
-    - php: hhvm-nightly
 
 before_script:
   - composer self-update


### PR DESCRIPTION
Hhvm does not make nighly packages anymore for precise, so it's useless
to ask travis to run tests on this envirnoment. (see https://github.com/facebook/hhvm/issues/5220)