### PR TITLE
Add the needed classes for our menu in twig.

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/EventListener/DefaultMenuListener.php
+++ b/src/SumoCoders/FrameworkCoreBundle/EventListener/DefaultMenuListener.php
@@ -63,28 +63,6 @@ class DefaultMenuListener
             )
         );
 
-        $menuItem->setAttributes(
-            array(
-                'class' => 'dropdown',
-                'icon' => 'icon icon-angle',
-            )
-        );
-
-        $menuItem->setChildrenAttributes(
-            array(
-                'class' => 'dropdown-menu',
-                'role' => 'menu',
-            )
-        );
-
-        $menuItem->setLinkAttributes(
-            array(
-                'class' => 'menu-item dropdown-toggle',
-                'role' => 'button',
-                'aria-expanded' => 'false',
-            )
-        );
-
         $menuItem->setExtra('orderNumber', $order);
 
         // add the childs
@@ -101,12 +79,6 @@ class DefaultMenuListener
             } else {
                 $child = $value;
             }
-
-            $child->setLinkAttributes(
-                array(
-                    'class' => 'sub-menu-item',
-                )
-            );
 
             $menuItem->addChild($child);
         }

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/views/menu/menu.html.twig
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/views/menu/menu.html.twig
@@ -6,3 +6,16 @@
     {% endif %}
    {{ item.label|trans(item.getExtra('translation_params', {}), item.getExtra('translation_domain', 'messages'))|capitalize }}
 {% endblock %}
+
+{% block item %}
+    {% if item.parent.name == 'root' and item.hasChildren %}
+        {% set item = item.setLinkAttributes({ 'class': 'menu-item dropdown-toggle', 'role': 'button', 'aria-expended': false }) %}
+        {% set item = item.setAttributes({ 'class': 'dropdown', 'icon': 'icon icon-angle' }) %}
+        {% set item = item.setChildrenAttributes({ 'class': 'dropdown-menu', 'role': 'menu' }) %}
+    {% elseif item.parent.name == 'root' and not item.hasChildren %}
+        {% set item = item.setLinkAttributes({ 'class': 'menu-item' }) %}
+    {% elseif item.parent.name != 'root' and not item.hasChildren %}
+        {% set item = item.setLinkAttributes({ 'class': 'sub-menu-item' }) %}
+    {% endif %}
+    {{ parent() }}
+{% endblock %}


### PR DESCRIPTION
This has multiple advantages:

* no matter which way you add a menu item, the classes are correct
* our php does not know anything of our layout anymore
* it's easier for frontenders to change the layout without the need of diving in the php code