### PR TITLE
Highlight a selected menu item without children.

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/components/_navbar.scss
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/components/_navbar.scss
@@ -74,6 +74,12 @@
       margin-top: 0;
     }
 
+    .current .menu-item {
+      background-color: transparent;
+      border-left: 10px $brand-primary solid;
+      color: $gray;
+    }
+
     .menu-item {
       border-left: 10px transparent solid;
       color: $gray;


### PR DESCRIPTION
It was nicely highlighted on hover and on focus, but when on the page, no additional styles were added.

This worked perfectly for items with children, but not for menu items without children.