### PR TITLE
Add option to set an icon on a button

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Form/Extension/ButtonTypeIconExtension.php
+++ b/src/SumoCoders/FrameworkCoreBundle/Form/Extension/ButtonTypeIconExtension.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SumoCoders\FrameworkCoreBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class ButtonTypeIconExtension extends AbstractTypeExtension
+{
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->setAttribute('icon', $options['icon']);
+    }
+
+    /**
+     * @param FormView      $view
+     * @param FormInterface $form
+     * @param array         $options
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['icon'] = $options['icon'];
+    }
+
+    /**
+     * @param OptionsResolverInterface $resolver
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults([
+            'icon' => null,
+        ]);
+    }
+
+    /**
+     * Extend the button field type
+     *
+     * @return string The name of the type being extended
+     */
+    public function getExtendedType()
+    {
+        return 'Symfony\Component\Form\Extension\Core\Type\ButtonType';
+    }
+}

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/config/services.yml
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/config/services.yml
@@ -43,6 +43,11 @@ services:
     tags:
       - { name: form.type_extension, alias: date }
 
+  framework.button_type_icon_extension:
+    class: SumoCoders\FrameworkCoreBundle\Form\Extension\ButtonTypeIconExtension
+    tags:
+        - { name: form.type_extension, extended-type: Symfony\Component\Form\Extension\Core\Type\ButtonType }
+
   twig.framework_extension:
     class: SumoCoders\FrameworkCoreBundle\Twig\FrameworkExtension
     arguments:

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/views/Form/fields.html.twig
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/views/Form/fields.html.twig
@@ -294,3 +294,23 @@
     {% endif %}
   {% endspaceless %}
 {% endblock form_row %}
+
+{% block button_widget -%}
+  {% set attr = attr|merge({class: (attr.class|default('') ~ ' btn')|trim}) %}
+  {% if label is empty -%}
+    {%- if label_format is not empty -%}
+      {% set label = label_format|replace({
+      '%name%': name,
+      '%id%': id,
+      }) %}
+    {%- else -%}
+      {% set label = name|humanize %}
+    {%- endif -%}
+  {%- endif -%}
+  {% if icon|default %}
+    {% set iconHtml = '<i class="' ~ icon ~ '"></i> ' %}
+  {% else %}
+    {% set iconHtml = '' %}
+  {% endif %}
+  <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ iconHtml|raw }}{{ label|trans({}, translation_domain) }}</button>
+{%- endblock button_widget %}


### PR DESCRIPTION
At the moment, for example in the FrameworkUserBundle icons are added by setting the icon classes to the buttons
This changes the font of the button to the icon font making it not match the rest of the application
By extending this button it is now possible to add an icon to that button

In the template:
```twig
{{ form_widget(form.example, {
    'icon': 'fa fa-bug',
    'label': 'Bug',
    'attr':{'class': 'btn btn-large btn-default btn-block' }
}) }}
```
Or in the controller
```php
    $builder
        ->add('example', SubmitType::class, [
                'label' => 'Bug',
                'icon' => 'fa fa-bug',
                'attr' => [
                    'class' => 'btn btn-large btn-default btn-block',
                ],
            ]
        );
```