### PR TITLE
Disable firephp and firephp

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -17,12 +17,12 @@ monolog:
             type:  stream
             path:  %kernel.logs_dir%/%kernel.environment%.log
             level: debug
-        firephp:
-            type:  firephp
-            level: info
-        chromephp:
-            type:  chromephp
-            level: info
+#        firephp:
+#            type:  firephp
+#            level: info
+#        chromephp:
+#            type:  chromephp
+#            level: info
 
 #swiftmailer:
 #    delivery_address: me@example.com


### PR DESCRIPTION
In dev-mode some response-headers can be extremly large and this will
result in a white page.