### PR TITLE
Don't put collection-items in a form-group

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/plugins/_collections.scss
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/plugins/_collections.scss
@@ -3,10 +3,8 @@
 }
 
 .collection-item {
-  @extend .row;
+  @include clearfix;
   @extend .well;
   @extend .well-sm;
   margin-bottom: $font-size-base * .7;
-  margin-left: 0;
-  margin-right: 0;
 }

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/views/Form/fields.html.twig
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/views/Form/fields.html.twig
@@ -197,7 +197,7 @@
       {% set widget_form_group_attr = widget_form_group_attr|merge({'class': widget_form_group_attr.class|default('row') ~ ' ' ~ attr.class}) %}
     {% endif %}
     {# collection item adds class {form_id}_form-group  too #}
-    {% set widget_form_group_attr = widget_form_group_attr|merge({'id': 'collection' ~ id ~ '_form_group', 'class': widget_form_group_attr.class ~ ' collection-items ' ~ id ~ '_form_group'}) %}
+    {% set widget_form_group_attr = widget_form_group_attr|merge({'id': 'collection' ~ id ~ '_form_group', 'class': 'collection-items ' ~ id ~ '_form_group'}) %}
 
     <div {% for attrname,attrvalue in widget_form_group_attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
       {# Add initial prototype form #}


### PR DESCRIPTION
The collection-items element used to get a form-group class which screwed up the alignment, because a form-group was being put inside a form-group.