### PR TITLE
Fix going to the correct item when clicking in a row

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/coffee/framework.coffee
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/coffee/framework.coffee
@@ -310,6 +310,6 @@ class Framework extends DefaultObject
     )
 
   clickableTablerow: ->
-    window.document.location = $('.action a').attr("href")
+    window.document.location = $(this).closest('tr').find('.action a').attr("href")
 
 window.Framework = Framework


### PR DESCRIPTION
Now it always went to the first item