### PR TITLE
add remember me functionality.

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -22,6 +22,10 @@ security:
                 path: fos_user_security_logout
                 target: fos_user_security_login
             anonymous: true
+            remember_me:
+                secret: %secret%
+                lifetime: 604800
+                path: /
         dev:
             pattern:  ^/(_(profiler|wdt)|css|images|js)/
             security: false


### PR DESCRIPTION
We show the "remember me" checkbox, but it isn't configured to work. As
stated in http://symfony.com/doc/2.8/cookbook/security/remember_me.html,
remember needs some extra configuration in the security.yml file.