### PR TITLE
Add .icon class to iconfont template so it can be extended

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/base/_iconfont-template.scss
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/base/_iconfont-template.scss
@@ -9,6 +9,7 @@
   font-style: normal;
 }
 
+.icon,
 <%= glyphs.map(function(glyph){ return '.' + className + '-' + glyph.name + ':before' }).join(',\n') %>,
 <%= glyphs.map(function(glyph){ return '.' + className + '-right-' + glyph.name + ':after' }).join(',\n') %> {
   font-family: "<%= fontName %>";


### PR DESCRIPTION
.icon class can be extended now to use on other elements.