### PR TITLE
Make it possible to add fields from the builder to a fieldset.

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Form/Type/FieldsetType.php
+++ b/src/SumoCoders/FrameworkCoreBundle/Form/Type/FieldsetType.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SumoCoders\FrameworkCoreBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class FieldsetType extends AbstractType
+{
+    /**
+     * @param OptionsResolverInterface $resolver
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver
+            ->setDefaults(
+                [
+                    'fieldset_class' => '',
+                    'legend_class' => '',
+                    'legend' => '',
+                    'virtual' => true,
+                    'options' => [],
+                    'fields' => [],
+                    'open_row' => false,
+                    'close_row' => false,
+                ]
+            )
+            ->addAllowedTypes(
+                [
+                    'fields' => ['array', 'callable'],
+                ]
+            );
+    }
+
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if (empty($options['fields'])) {
+            return;
+        }
+
+        if (is_callable($options['fields'])) {
+            $options['fields']($builder);
+
+            return;
+        }
+
+        foreach ($options['fields'] as $field) {
+            $builder->add($field['name'], $field['type'], $field['attr']);
+        }
+    }
+
+    /**
+     * @param FormView $view
+     * @param FormInterface $form
+     * @param array $options
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        if (false !== $options['legend']) {
+            $view->vars['legend'] = $options['legend'];
+        }
+        if (false !== $options['open_row']) {
+            $view->vars['open_row'] = $options['open_row'];
+        }
+        if (false !== $options['close_row']) {
+            $view->vars['close_row'] = $options['close_row'];
+        }
+        if (!empty($options['fieldset_class'])) {
+            $view->vars['fieldset_class'] = $options['fieldset_class'];
+        }
+        if (!empty($options['legend_class'])) {
+            $view->vars['legend_class'] = $options['legend_class'];
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'fieldset';
+    }
+}

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/config/services.yml
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/config/services.yml
@@ -67,3 +67,8 @@ services:
       - [setDefaultReplyTo, ["%mailer_default_reply_to_email%", "%mailer_default_reply_to_name%"]]
       - [setDefaultTo, ["%mailer_default_to_email%", "%mailer_default_to_name%"]]
 
+  sumocoders_form_type_fieldset:
+    class: SumoCoders\FrameworkCoreBundle\Form\Type\FieldsetType
+    arguments: []
+    tags:
+        - { name: form.type, alias: fieldset }

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/views/Form/fields.html.twig
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/views/Form/fields.html.twig
@@ -314,3 +314,19 @@
   {% endif %}
   <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ iconHtml|raw }}{{ label|trans({}, translation_domain) }}</button>
 {%- endblock button_widget %}
+
+{% block fieldset_row %}
+  {% if open_row is defined and open_row %}
+    <div class="row">
+  {% endif %}
+  <fieldset{% if fieldset_class is defined and fieldset_class is not empty %} class="{{ fieldset_class }}"{% endif %}>
+    {% if legend is defined and legend is not empty %}
+      <legend{% if legend_class is defined and legend_class is not empty %} class="{{ legend_class }}"{% endif %}>{{ legend|trans({}, translation_domain)|capitalize }}</legend>
+    {% endif %}
+    {{ block('form_widget') }}
+
+  </fieldset>
+  {% if close_row  is defined and close_row %}
+    </div>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Example implementation:
```
$builder->add(
    'fieldset',
    'fieldset',
    [
        'fieldset_class' => 'col-xs-12 col-sm-6',
        'open_row' => true,
        'legend' => 'my.fieldset.translation',
        'fields' => function (FormBuilderInterface $builder) {
            $builder
                ->add(
                    'input',
                    'text'
                );
        },
    ]
)
```