### PR TITLE
Update net-ssh to not throw deprecation notices.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
+    net-ssh (3.1.1)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     rb-fsevent (0.9.4)


### PR DESCRIPTION
Since ruby 2.3.0, the Object,Timeout method is throwing deprecation notices.
net-ssh still used this in the previous versions, but fixed this now.