### PR TITLE
Refactor flash class handling the js genereted messages

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/coffee/framework.flash.coffee
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/coffee/framework.flash.coffee
@@ -1,6 +1,6 @@
 class Flash
 
-  add: (message, type) ->
+  add: (message, type, time) ->
     alertId = Date.now();
 
     $('.main-header').append(
@@ -14,6 +14,10 @@ class Flash
             '  </div>' +
         '</div>'
     );
+
+    if time?
+      callback = => @remove(alertId)
+      setTimeout callback, time
 
     return alertId
 

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/coffee/framework.flash.coffee
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/coffee/framework.flash.coffee
@@ -4,7 +4,7 @@ class Flash
     alertId = Date.now();
 
     $('.main-header').append(
-        '<div class="alert alert-fixed alert-' + type + ' alert-dismissible notification" role="status" data-alert-id="' + alertId + '">' +
+        '<div class="alert alert-' + type + ' alert-dismissible notification" role="status" data-alert-id="' + alertId + '">' +
             '  <div class="container">' +
             '    <a class="close" data-dismiss="alert" title="' + Locale.lbl('Close') + '">' +
             '       <i class="fa fa-close"></i>' +

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/coffee/framework.flash.coffee
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/coffee/framework.flash.coffee
@@ -3,14 +3,15 @@ class Flash
   add: (message, type) ->
     alertId = Date.now();
 
-    $('body').prepend(
-      '<div class="alert alert-' + type + ' alert-dismissible notification" role="alert" data-alert-id="' + alertId + '">' +
-        '  <div class="container">' +
-        '    <button type="button" class="close" data-dismiss="alert"' +
-        '       title="' + Locale.lbl('Close') + '">' + Locale.lbl('Close') +
-        '    </button>' +
-        '    ' + message +
-        '  </div>' +
+    $('.main-header').append(
+        '<div class="alert alert-fixed alert-' + type + ' alert-dismissible notification" role="status" data-alert-id="' + alertId + '">' +
+            '  <div class="container">' +
+            '    <a class="close" data-dismiss="alert" title="' + Locale.lbl('Close') + '">' +
+            '       <i class="fa fa-close"></i>' +
+            '       <span class="hide">' + Locale.lbl('Close') + '</span>' +
+            '    </a>' +
+            '    ' + message +
+            '  </div>' +
         '</div>'
     );
 

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/components/_alerts.scss
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/components/_alerts.scss
@@ -10,6 +10,10 @@
       color: $gray-dark;
     }
   }
+
+  &.alert-fixed {
+    margin-bottom: 0;
+  }
 }
 
 .alert-dismissible .close {

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/components/_alerts.scss
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/components/_alerts.scss
@@ -10,10 +10,6 @@
       color: $gray-dark;
     }
   }
-
-  &.alert-fixed {
-    margin-bottom: 0;
-  }
 }
 
 .alert-dismissible .close {

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/layouts/_header.scss
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/layouts/_header.scss
@@ -121,6 +121,10 @@
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+
+    .alert {
+      margin-bottom: 0;
+    }
   }
 
   .sub-nav {


### PR DESCRIPTION
Changed the styling of the alert generated by `framework.flash.coffee` so it fits better with the symfony alerts.

now the alerts will have a fixed position under the navigation bar.

It's also possible to define for how long the alert should be visible
-> `Flash.add(message, 'success', 5000);`

When not defining the time, then the alert wont disappear until its closed or there is a page refresh