### PR TITLE
Set width of logo to 100% so IE respects the aspect ratio

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/components/_navbar.scss
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/sass/components/_navbar.scss
@@ -16,6 +16,7 @@
 
   .logo img {
     margin: 0 auto;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
If you don't set a width on a svg, IE will not respect the aspect ratio and the height will be off.