### PR TITLE
Remove sumo plugings from js group

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/views/empty.html.twig
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/views/empty.html.twig
@@ -45,7 +45,6 @@
         <script type="text/javascript" src="{{ asset('/assets/js/frameworkcorebundle.framework.form.search.js') }}"></script>
         <script type="text/javascript" src="{{ asset('/assets/js/frameworkcorebundle.app.js') }}"></script>
       {% else %}
-        <script type="text/javascript" src="{{ asset('/assets/js/sumo_plugins.js') }}"></script>
         <script type="text/javascript" src="{{ asset('/assets/js/framework.js') }}"></script>
       {% endif %}
     {% endblock %}


### PR DESCRIPTION
sumo_plugins.js get loaded on L38, but adding it in the JS-group will put everything from this group in this file, which will lead to lost JS-code and double JS-code.