### PR TITLE
Create a MatchAgainst parser 

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -62,6 +62,9 @@ doctrine:
   orm:
     auto_generate_proxy_classes: "%kernel.debug%"
     auto_mapping: true
+    dql:
+      string_functions:
+        MATCH_AGAINST: SumoCodersFrameworkCoreBundle\Extensions\Doctrine\MatchAgainst
 
 doctrine_migrations:
     dir_name: %kernel.root_dir%/migrations

--- a/src/SumoCoders/FrameworkCoreBundle/Extensions/Doctrine/MatchAgainst.php
+++ b/src/SumoCoders/FrameworkCoreBundle/Extensions/Doctrine/MatchAgainst.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SumoCoders\FrameworkCoreBundle\Extensions\Doctrine;
+
+use Doctrine\ORM\Query\AST\InputParameter;
+use Doctrine\ORM\Query\AST\Literal;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * "MATCH_AGAINST" "(" {StateFieldPathExpression ","}* InParameter {Literal}? ")"
+ */
+class MatchAgainst extends FunctionNode
+{
+    /** @var array */
+    private $columns = [];
+
+    /** @var string|InputParameter */
+    private $needle;
+
+    /** @var Literal */
+    private $mode;
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+        while ($parser->getLexer()->isNextToken(Lexer::T_IDENTIFIER)) {
+            $this->columns[] = $parser->StateFieldPathExpression();
+            $parser->match(Lexer::T_COMMA);
+        };
+
+        $this->needle = $parser->InParameter();
+
+        while ($parser->getLexer()->isNextToken(Lexer::T_STRING)) {
+            $this->mode = $parser->Literal();
+        }
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        $haystack = null;
+        $first = true;
+        foreach ($this->columns as $column) {
+            if (!$first) {
+                $haystack .= ', ';
+            }
+
+            $first = false;
+
+            $haystack .= $column->dispatch($sqlWalker);
+        }
+
+        $query = "MATCH(" . $haystack . ") AGAINST (" . $this->needle->dispatch($sqlWalker);
+
+        if ($this->mode) {
+            $query .= " " . $this->mode->value . " )";
+        } else {
+            $query .= " )";
+        }
+
+        return $query;
+    }
+}


### PR DESCRIPTION
Create a MatchAgainst parser which allows us to use full text search in doctrine queries

example usage:
```
...
WHERE MATCH_AGAINST(myContentField, :my_term 'IN NATURAL LANGUAGE MODE') > 0.3
...
```