### PR TITLE
Set database charset to utf8mb4 in config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -63,7 +63,7 @@ doctrine:
     dbname:   "%database_name%"
     user:     "%database_user%"
     password: "%database_password%"
-    charset:  UTF8
+    charset:  UTF8MB4
     server_version: "%database_version%"
     types:
       user_status: SumoCoders\FrameworkMultiUserBundle\DBALType\StatusType


### PR DESCRIPTION
fixes #106 
Sets the database charset to UTF8MB4.
The annotations for entities should add the options so migrations are made correctly

```
/**
 * @ORM\Entity
 * @ORM\Table(options={"collate":"utf8mb4_general_ci", "charset":"utf8mb4"})
 */ ```