### PR TITLE
Create the needed dirs

### DIFF
--- a/app/config/capistrano/tasks/framework.rake
+++ b/app/config/capistrano/tasks/framework.rake
@@ -8,6 +8,7 @@ namespace :framework do
           warn Airbrussh::Colors.yellow('⚠') + " to link it to the deploy, issue the following command:"
           warn Airbrussh::Colors.yellow('⚠') + " ln -sf #{fetch :deploy_to}/current #{fetch :document_root}"
         else
+          execute :mkdir, "-p", File.dirname(fetch(:document_root))
           execute :ln, "-s", "#{fetch :deploy_to}/current/web", "#{fetch :document_root}"
         end
       end


### PR DESCRIPTION
When we make the symlink to the document root. In some cases it can happen that the containing folder does not exist.
So we should create them before the symlink is created.