### PR TITLE
Travis trusty as default linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - mkdir -p web/assets/css && touch web/assets/css/style.css
 
   # generate all required assets
-  - gulp --gulpfile gulp-travis.js build
+  - node_modules/.bin/gulp --gulpfile gulp-travis.js build
   - php app/console assets:instal --env=test
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ services:
 before_script:
   - composer self-update
   - mysql -e 'create database app_test'
-  - "sed 's/database_name:*/database_name: app_test/' app/config/parameters.yml.dist | sed 's/database_user:*/database_user: travis/' | sed 's/database_password:*/database_password:/' > app/config/parameters.yml"
+  - "sed 's/database_name:*/database_name: app_test/' app/config/parameters.yml.dist | sed 's/database_user:*/database_user: root/' | sed 's/database_password:*/database_password:/' > app/config/parameters.yml"
   - composer install --prefer-source --no-interaction --no-scripts
   - composer run-script post-travis
   - php app/console doctrine:migration:migrate --env=test --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: precise
-
 sudo: false
 
 env:
@@ -19,6 +17,9 @@ matrix:
     - php: 5.5
     - php: nightly
     - php: hhvm
+
+services:
+  - mysql
 
 before_script:
   - composer self-update


### PR DESCRIPTION
This PR allows our travis setup to run on ubuntu trusty instead of precise.