### PR TITLE
Replace raw tag with verbatim.

### DIFF
--- a/app/Resources/SensioGeneratorBundle/skeleton/bundle/index.html.twig.twig
+++ b/app/Resources/SensioGeneratorBundle/skeleton/bundle/index.html.twig.twig
@@ -7,6 +7,6 @@
 {{ '{% endblock %}' }}
 
 {{ '{% block main %}' }}
-<p>Hello {% raw %}{{ name }}{% endraw %}</p>
+<p>Hello {% verbatim %}{{ name }}{% endverbatim %}</p>
 {{ '{% endblock %}' }}
 


### PR DESCRIPTION
This PR replaces the `raw` Twig tag from our custom templates for the SensioGeneratorBundle with `verbatim`.

The usage of `raw` generates the following error:
```
[Twig_Error_Syntax]
  Unknown "raw" tag.
```