### PR TITLE
Implement basic user switching

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -20,6 +20,7 @@ security:
             guard:
                 authenticators:
                     - sumocoders.form_authenticator
+            switch_user: true
         dev:
             pattern:  ^/(_(profiler|wdt)|css|images|js)/
             security: false

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "jms/di-extra-bundle": "^1.7",
         "sumocoders/framework-search-bundle": "^4.0.0",
         "sumocoders/framework-example-bundle": "^8.0.0",
-        "sumocoders/framework-multi-user-bundle": "^8.0.0",
+        "sumocoders/framework-multi-user-bundle": "^8.1.0",
         "simple-bus/symfony-bridge": "^4.1",
         "simple-bus/doctrine-orm-bridge": "^4.0",
         "gedmo/doctrine-extensions": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "43901b7a94e7a01bf8822baa372fa677",
+    "content-hash": "35429212e6e3547f32088555593792d8",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -3059,17 +3059,17 @@
         },
         {
             "name": "sumocoders/framework-multi-user-bundle",
-            "version": "8.0.1",
+            "version": "8.1.0",
             "target-dir": "SumoCoders/FrameworkMultiUserBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sumocoders/FrameworkMultiUserBundle.git",
-                "reference": "1b8fdbbd60c54d82ea510b9c7cbb4ba2bd817231"
+                "reference": "92f75155eaac1b887e061173cb1d3b124e7eb4c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sumocoders/FrameworkMultiUserBundle/zipball/1b8fdbbd60c54d82ea510b9c7cbb4ba2bd817231",
-                "reference": "1b8fdbbd60c54d82ea510b9c7cbb4ba2bd817231",
+                "url": "https://api.github.com/repos/sumocoders/FrameworkMultiUserBundle/zipball/92f75155eaac1b887e061173cb1d3b124e7eb4c8",
+                "reference": "92f75155eaac1b887e061173cb1d3b124e7eb4c8",
                 "shasum": ""
             },
             "require": {
@@ -3124,7 +3124,7 @@
                 "SumoCoders",
                 "framework"
             ],
-            "time": "2017-10-23T08:46:06+00:00"
+            "time": "2017-10-24T09:34:56+00:00"
         },
         {
             "name": "sumocoders/framework-search-bundle",

--- a/src/SumoCoders/FrameworkCoreBundle/Resources/views/base.html.twig
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/views/base.html.twig
@@ -92,7 +92,11 @@
                             {{ 'user.actions.settings'|trans|capitalize }}
                           </a>
                         </li>
-                        <li><a href="{{ path('multi_user_logout') }}">{{ 'user.actions.logout'|trans|capitalize }}</a></li>
+                        {% if is_granted('ROLE_PREVIOUS_ADMIN') %}
+                          <li><a href="{{ path('sumocoders_frameworkuser_index_index') }}?_switch_user=_exit">{{ 'user.actions.switchBack'|trans|capitalize }}</a></li>
+                        {% else %}
+                          <li><a href="{{ path('multi_user_logout') }}">{{ 'user.actions.logout'|trans|capitalize }}</a></li>
+                        {% endif %}
                       </ul>
                     </div>
                   {% endif %}

--- a/src/SumoCoders/FrameworkUserBundle/Entity/Admin.php
+++ b/src/SumoCoders/FrameworkUserBundle/Entity/Admin.php
@@ -3,6 +3,7 @@
 namespace SumoCoders\FrameworkUserBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use SumoCoders\FrameworkMultiUserBundle\Entity\BaseUser;
 
 /**
  * @ORM\Entity(repositoryClass="SumoCoders\FrameworkUserBundle\Repository\AdminRepository")
@@ -13,5 +14,10 @@ final class Admin extends User
     public function getRoles(): array
     {
         return ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'];
+    }
+
+    public function canSwitchTo(BaseUser $user): bool
+    {
+        return !($user instanceof self) && !$user->isBlocked();
     }
 }

--- a/src/SumoCoders/FrameworkUserBundle/Entity/User.php
+++ b/src/SumoCoders/FrameworkUserBundle/Entity/User.php
@@ -26,9 +26,4 @@ class User extends BaseUser
     {
         return ['ROLE_USER'];
     }
-
-    public function canSwitchTo(BaseUser $user): bool
-    {
-        return false;
-    }
 }

--- a/src/SumoCoders/FrameworkUserBundle/Entity/User.php
+++ b/src/SumoCoders/FrameworkUserBundle/Entity/User.php
@@ -26,4 +26,9 @@ class User extends BaseUser
     {
         return ['ROLE_USER'];
     }
+
+    public function canSwitchTo(BaseUser $user): bool
+    {
+        return false;
+    }
 }

--- a/src/SumoCoders/FrameworkUserBundle/EventListener/SwitchUserListener.php
+++ b/src/SumoCoders/FrameworkUserBundle/EventListener/SwitchUserListener.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SumoCoders\FrameworkUserBundle\EventListener;
+
+use SumoCoders\FrameworkMultiUserBundle\Entity\BaseUser;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Role\SwitchUserRole;
+use Symfony\Component\Security\Http\Event\SwitchUserEvent;
+
+final class SwitchUserListener
+{
+    /** @var TokenStorageInterface */
+    private $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function onSwitchUser(SwitchUserEvent $event): void
+    {
+        $impersonator = $this->getImpersonatingUser();
+
+        $impersonatingUser = $this->tokenStorage->getToken()->getUser();
+        $impersonatedUser = $event->getTargetUser();
+
+        // If a user is impersonating, check if we want to switch back, in that case
+        // $user will be the same as the user doing the impersonating.
+        if ($impersonator instanceof BaseUser && $impersonator->getId() === $event->getTargetUser()->getId()) {
+            $impersonatedUser = $this->tokenStorage->getToken()->getUser();
+            $impersonatingUser = $event->getTargetUser();
+        }
+
+        if (!$impersonatingUser->canSwitchTo($impersonatedUser)) {
+            throw new AccessDeniedException();
+        }
+    }
+
+    private function getImpersonatingUser(): ?BaseUser
+    {
+        foreach ($this->tokenStorage->getToken()->getRoles() as $role) {
+            if ($role instanceof SwitchUserRole) {
+                return $role->getSource()->getUser();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/SumoCoders/FrameworkUserBundle/Resources/config/listeners.yml
+++ b/src/SumoCoders/FrameworkUserBundle/Resources/config/listeners.yml
@@ -6,3 +6,10 @@ services:
       - "@security.token_storage"
     tags:
       - { name: kernel.event_listener, event: framework_core.configure_menu, method: onConfigureMenu }
+
+  sumo_coders.user.listener.switch_user:
+    class: SumoCoders\FrameworkUserBundle\EventListener\SwitchUserListener
+    arguments:
+      - "@security.token_storage"
+    tags:
+      - { name: kernel.event_listener, event: security.switch_user, method: onSwitchUser }

--- a/src/SumoCoders/FrameworkUserBundle/Resources/translations/messages.en.yml
+++ b/src/SumoCoders/FrameworkUserBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,47 @@
+sumo_coders.user.route:
+  add_user: add user
+  add_admin: add admin
+  edit_user: edit user
+  edit_admin: edit admin
+
+user:
+  header:
+    index: overview users
+
+  menu:
+    index: users
+
+  actions:
+    add:
+      user: add user
+      admin: add admin
+    settings: settings
+    logout: logout
+    switchBack: back to original user
+
+  datagrid:
+    email: e-mail
+    type: type
+
+    actions:
+      block: block
+      unblock: unblock
+      switchTo: switch to
+
+  dialogs:
+    messages:
+      confirmBlock: Are you sure you want to block user "%user%"?
+      confirmUnblock: Are you sure you want to unblock user "%user%"?
+      confirmSwitch: Are you sure you want to switch to user "%user%"?
+
+  types:
+    user: user
+    admin: admin
+
+  form:
+    submit: save
+
+  displayName: display name
+  email: e-mail
+  plainPassword.first: password
+  plainPassword.second: confirm password

--- a/src/SumoCoders/FrameworkUserBundle/Resources/translations/messages.nl.yml
+++ b/src/SumoCoders/FrameworkUserBundle/Resources/translations/messages.nl.yml
@@ -17,6 +17,7 @@ user:
       admin: beheerder toevoegen
     settings: instellingen
     logout: uitloggen
+    switchBack: naar originele gebruiker
 
   datagrid:
     email: e-mailadres
@@ -25,11 +26,13 @@ user:
     actions:
       block: blokkeer
       unblock: deblokkeer
+      switchTo: overschakelen
 
   dialogs:
     messages:
       confirmBlock: Ben je zeker dat je "%user%" wilt blokkeren?
       confirmUnblock: Ben je zeker dat je "%user%" wilt deblokkeren?
+      confirmSwitch: Ben je zeker dat je naar "%user%" wilt overschakelen?
 
   types:
     user: gebruiker

--- a/src/SumoCoders/FrameworkUserBundle/Resources/views/Index/index.html.twig
+++ b/src/SumoCoders/FrameworkUserBundle/Resources/views/Index/index.html.twig
@@ -25,6 +25,7 @@
         <th>{{ 'user.datagrid.type'|trans|capitalize }}</th>
         <th></th>
         <th></th>
+        <th></th>
       </tr>
     </thead>
     <tbody>
@@ -36,6 +37,20 @@
               {{ 'user.types.admin'|trans }}
             {% else %}
               {{ 'user.types.user'|trans }}
+            {% endif %}
+          </td>
+          <td class="action">
+            {% if not user.isBlocked() and app.user.canSwitchTo(user) %}
+              {# todo switch route to homepage? #}
+              <a
+                href="{{ path('sumocoders_frameworkexample_bootstrap_select2') }}?_switch_user={{ user.username }}"
+                class="fa fa-refresh confirm"
+                data-toggle="tooltip"
+                title="{{ 'user.datagrid.actions.switchTo'|trans }}"
+                data-message="{{ 'user.dialogs.messages.confirmSwitch'|trans({'%user%': user.username}) }}"
+              >
+                <span class="hide">{{ 'user.datagrid.actions.switchTo'|trans }}</span>
+              </a>
             {% endif %}
           </td>
           <td class="action">


### PR DESCRIPTION
Implement a basic working of user switching, only available for admins.

The link (icon) to switch to an user is shown in the user overview. To switch back use the link replacing the logout button in the top right menu.