### PR TITLE
Rotate production log

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -12,9 +12,10 @@ monolog:
             action_level: error
             handler:      nested
         nested:
-            type:  stream
+            type:  rotating_file
             path:  %kernel.logs_dir%/%kernel.environment%.log
             level: debug
+            max_files: 10
         console:
             type: console
             process_psr_3_messages: false

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -8,12 +8,12 @@ twig:
 monolog:
     handlers:
         main:
-            type:         fingers_crossed
+            type: fingers_crossed
             action_level: error
-            handler:      nested
+            handler: nested
         nested:
-            type:  rotating_file
-            path:  %kernel.logs_dir%/%kernel.environment%.log
+            type: rotating_file
+            path: %kernel.logs_dir%/%kernel.environment%.log
             level: debug
             max_files: 10
         console:


### PR DESCRIPTION
This PR implements log rotation using Monolog. The log rotates every day and logs from previous days are kept to a maximum of 10 files.