### PR TITLE
Disable the useCurrent option on the datepickers

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/js/Framework/Form.js
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/js/Framework/Form.js
@@ -46,6 +46,7 @@ export class Form {
         format: format,
         minDate: startDate,
         maxDate: endDate,
+        useCurrent: false,
         keepOpen: true,
         icons: {
           time: "fa fa-clock-o",


### PR DESCRIPTION
That option will result in the datepicker ignoring the current value and just set the current date, or the closed valid date to today

see https://github.com/Eonasdan/bootstrap-datetimepicker/issues/1075