### PR TITLE
Update twig/extensions to match composer lock file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/migrations": "^1.4",
         "doctrine/doctrine-migrations-bundle": "^1.1",
-        "twig/extensions": "^1.3",
+        "twig/extensions": "^1.5",
         "symfony/swiftmailer-bundle": "^2.3",
         "symfony/monolog-bundle": "^3.0",
         "sensio/distribution-bundle": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "48035d5ad1e938a3ce4558895053c871",
+    "content-hash": "4d3144cd3920df592738bb2c97f80ac5",
     "packages": [
         {
             "name": "beberlei/assert",


### PR DESCRIPTION
The lock file already had version 1.5.1, so updated json file to match that.

Replacement of #230 