### PR TITLE
Add validator to check for unique fields when using a DataTransferObject

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/config/services.yml
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/config/services.yml
@@ -113,3 +113,9 @@ services:
     tags:
       - { name: form.type, alias: otherChoiceType }
 
+  sumocoders_validator_unique_data_transfer_object:
+    class: SumoCoders\FrameworkCoreBundle\Validator\UniqueDataTransferObjectValidator
+    arguments:
+      - "@doctrine"
+    tags:
+      - { name: validator.constraint_validator, alias: unique_data_transfer_object }

--- a/src/SumoCoders/FrameworkCoreBundle/Validator/UniqueDataTransferObject.php
+++ b/src/SumoCoders/FrameworkCoreBundle/Validator/UniqueDataTransferObject.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SumoCoders\FrameworkCoreBundle\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Constraint for the Unique Entity validator.
+ *
+ * @Annotation
+ * @Target({"CLASS", "ANNOTATION"})
+ */
+class UniqueDataTransferObject extends Constraint
+{
+    const NOT_UNIQUE_ERROR = '23bd9dbf-6b9b-41cd-a99e-4844bcf3077f';
+
+    public $message = 'This value is already used.';
+    public $service = 'unique_data_transfer_object';
+    public $em = null;
+    public $entityClass = null;
+    public $repositoryMethod = 'findBy';
+    public $fields = array();
+    public $errorPath = null;
+    public $ignoreNull = true;
+
+    protected static $errorNames = array(
+        self::NOT_UNIQUE_ERROR => 'NOT_UNIQUE_ERROR',
+    );
+
+    public function getRequiredOptions()
+    {
+        return array('fields');
+    }
+
+    /**
+     * The validator must be defined as a service with this name.
+     *
+     * @return string
+     */
+    public function validatedBy()
+    {
+        return $this->service;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    public function getDefaultOption()
+    {
+        return 'fields';
+    }
+}

--- a/src/SumoCoders/FrameworkCoreBundle/Validator/UniqueDataTransferObjectValidator.php
+++ b/src/SumoCoders/FrameworkCoreBundle/Validator/UniqueDataTransferObjectValidator.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace SumoCoders\FrameworkCoreBundle\Validator;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Unique Entity Validator checks if one or a set of fields contain unique values.
+ */
+class UniqueDataTransferObjectValidator extends ConstraintValidator
+{
+    private $registry;
+
+    public function __construct(ManagerRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * @param object $dataTransferObject
+     * @param Constraint $constraint
+     *
+     * @throws UnexpectedTypeException
+     * @throws ConstraintDefinitionException
+     */
+    public function validate($dataTransferObject, Constraint $constraint): void
+    {
+        if (!$constraint instanceof UniqueDataTransferObject) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\UniqueDataTransferObject');
+        }
+
+        if (!\is_array($constraint->fields) && !\is_string($constraint->fields)) {
+            throw new UnexpectedTypeException($constraint->fields, 'array');
+        }
+
+        if ($constraint->errorPath !== null && !\is_string($constraint->errorPath)) {
+            throw new UnexpectedTypeException($constraint->errorPath, 'string or null');
+        }
+
+        $fields = (array) $constraint->fields;
+
+        if (\count($fields) === 0) {
+            throw new ConstraintDefinitionException('At least one field has to be specified.');
+        }
+
+        if ($dataTransferObject === null) {
+            return;
+        }
+
+        if ($constraint->em) {
+            $em = $this->registry->getManager($constraint->em);
+
+            if (!$em) {
+                throw new ConstraintDefinitionException(
+                    sprintf('Object manager "%s" does not exist.', $constraint->em)
+                );
+            }
+        } else {
+            $em = $this->registry->getManagerForClass(
+                $constraint->entityClass ?? \get_class($dataTransferObject->getEntity())
+            );
+
+            if (!$em) {
+                $em = $this->registry->getManager();
+            }
+        }
+
+        $class = $em->getClassMetadata($constraint->entityClass ?? \get_class($dataTransferObject->getEntity()));
+        /* @var $class \Doctrine\Common\Persistence\Mapping\ClassMetadata */
+
+        $criteria = array();
+        $hasNullValue = false;
+
+        foreach ($fields as $fieldName) {
+            if (!$class->hasField($fieldName) && !$class->hasAssociation($fieldName)) {
+                throw new ConstraintDefinitionException(
+                    sprintf(
+                        'The field "%s" is not mapped by Doctrine, so it cannot be validated for uniqueness.',
+                        $fieldName
+                    )
+                );
+            }
+
+            $fieldValue = $dataTransferObject->$fieldName;
+
+            if ($fieldValue === null) {
+                $hasNullValue = true;
+            }
+
+            if ($constraint->ignoreNull && $fieldValue === null) {
+                continue;
+            }
+
+            $criteria[$fieldName] = $fieldValue;
+
+            if ($criteria[$fieldName] !== null && $class->hasAssociation($fieldName)) {
+                /* Ensure the Proxy is initialized before using reflection to
+                 * read its identifiers. This is necessary because the wrapped
+                 * getter methods in the Proxy are being bypassed.
+                 */
+                $em->initializeObject($criteria[$fieldName]);
+            }
+        }
+
+        // validation doesn't fail if one of the fields is null and if null values should be ignored
+        if ($hasNullValue && $constraint->ignoreNull) {
+            return;
+        }
+
+        // skip validation if there are no criteria (this can happen when the
+        // "ignoreNull" option is enabled and fields to be checked are null
+        if (empty($criteria)) {
+            return;
+        }
+
+        if ($constraint->entityClass !== null) {
+            /* Retrieve repository from given entity name.
+             * We ensure the retrieved repository can handle the entity
+             * by checking the entity is the same, or subclass of the supported entity.
+             */
+            $repository = $em->getRepository($constraint->entityClass);
+            $supportedClass = $repository->getClassName();
+
+            if ($dataTransferObject->getEntity() !== null
+                && !$dataTransferObject->getEntity() instanceof $supportedClass) {
+                throw new ConstraintDefinitionException(
+                    sprintf(
+                        'The "%s" entity repository does not support the "%s" entity. The entity should be an instance of or extend "%s".',
+                        $constraint->entityClass,
+                        $class->getName(),
+                        $supportedClass
+                    )
+                );
+            }
+        } else {
+            $repository = $em->getRepository(\get_class($dataTransferObject->getEntity()));
+        }
+
+        $result = $repository->{$constraint->repositoryMethod}($criteria);
+
+        if ($result instanceof \IteratorAggregate) {
+            $result = $result->getIterator();
+        }
+
+        /* If the result is a MongoCursor, it must be advanced to the first
+         * element. Rewinding should have no ill effect if $result is another
+         * iterator implementation.
+         */
+        if ($result instanceof \Iterator) {
+            $result->rewind();
+        } elseif (\is_array($result)) {
+            reset($result);
+        }
+
+        /* If no entity matched the query criteria or a single entity matched,
+         * which is the same as the entity being validated, the criteria is
+         * unique.
+         */
+        if (\count($result) === 0
+            || (
+                \count($result) === 1
+                && $dataTransferObject->getEntity() === ($result instanceof \Iterator ? $result->current() : current($result))
+            )) {
+            return;
+        }
+
+        $errorPath = $constraint->errorPath ?? $fields[0];
+        $invalidValue = $criteria[$errorPath] ?? $criteria[$fields[0]];
+
+        $this->context->buildViolation($constraint->message)
+            ->atPath($errorPath)
+            ->setParameter('{{ value }}', $this->formatWithIdentifiers($em, $class, $invalidValue))
+            ->setInvalidValue($invalidValue)
+            ->setCode(UniqueDataTransferObject::NOT_UNIQUE_ERROR)
+            ->setCause($result)
+            ->addViolation();
+    }
+
+    private function formatWithIdentifiers(ObjectManager $em, ClassMetadata $class, $value)
+    {
+        if (!\is_object($value) || $value instanceof \DateTimeInterface) {
+            return $this->formatValue($value, self::PRETTY_DATE);
+        }
+
+        if ($class->getName() !== $idClass = \get_class($value)) {
+            // non unique value might be a composite PK that consists of other entity objects
+            if ($em->getMetadataFactory()->hasMetadataFor($idClass)) {
+                $identifiers = $em->getClassMetadata($idClass)->getIdentifierValues($value);
+            } else {
+                // this case might happen if the non unique column has a custom doctrine type and its value is an object
+                // in which case we cannot get any identifiers for it
+                $identifiers = array();
+            }
+        } else {
+            $identifiers = $class->getIdentifierValues($value);
+        }
+
+        if (!$identifiers) {
+            return sprintf('object("%s")', $idClass);
+        }
+
+        array_walk(
+            $identifiers,
+            function (&$id, $field) {
+                if (!\is_object($id) || $id instanceof \DateTimeInterface) {
+                    $idAsString = $this->formatValue($id, self::PRETTY_DATE);
+                } else {
+                    $idAsString = sprintf('object("%s")', \get_class($id));
+                }
+
+                $id = sprintf('%s => %s', $field, $idAsString);
+            }
+        );
+
+        return sprintf('object("%s") identified by (%s)', $idClass, implode(', ', $identifiers));
+    }
+}


### PR DESCRIPTION
Usage example:
/**
 * @UniqueDataTransferObject(fields={email}, message=contact.form.unique_email, entityClass=DatabaseEffectiveMediaContactsBundleDomainContactContact, ignoreNull=true)
 */
class ContactDataTransferObject