### PR TITLE
Use correct bin

### DIFF
--- a/app/config/capistrano/stages/staging.rb
+++ b/app/config/capistrano/stages/staging.rb
@@ -9,7 +9,6 @@ set :keep_releases,  2
 set :url, "http://#{fetch :project}.#{fetch :client}.php71.sumocoders.eu"
 
 set :php_bin, 'php7.1'
-set :php_bin_custom_path, fetch(:php_bin)
 
 set :opcache_reset_strategy, 'fcgi'
 set :opcache_reset_fcgi_connection_string, '/var/run/php_71_fpm_sites.sock'

--- a/app/config/capistrano/tasks/configure.rake
+++ b/app/config/capistrano/tasks/configure.rake
@@ -6,7 +6,7 @@ namespace :framework do
     DESC
     task :cachetool do
       # Set the correct bin
-      SSHKit.config.command_map[:cachetool] = "#{fetch :php_bin_path} #{fetch :deploy_to}/shared/cachetool.phar"
+      SSHKit.config.command_map[:cachetool] = "#{fetch :php_bin} #{fetch :deploy_to}/shared/cachetool.phar"
     end
   end
 end


### PR DESCRIPTION
The Cachetool was using the default php-binary. 
On staging we have multiple PHP versions, so we need to prepend it.