### PR TITLE
Remove container from alert

### DIFF
--- a/src/SumoCoders/FrameworkCoreBundle/Resources/assets/js/Framework/Flash.js
+++ b/src/SumoCoders/FrameworkCoreBundle/Resources/assets/js/Framework/Flash.js
@@ -7,12 +7,10 @@ export class Flash {
 
     $('.main-header').append(
         `<div class="alert alert-${type} alert-dismissible notification" role="status" data-alert-id="${alertId}">
-        <div class="container">
-          <a class="close" data-dismiss="alert" title="${locale.lbl('core.interface.close')}">
-            <i class="fa fa-close"></i>
-            <span class="hide">${locale.lbl('core.interface.close')}</span>
-          </a> ${message}
-        </div>
+        <a class="close" data-dismiss="alert" title="${locale.lbl('core.interface.close')}">
+          <i class="fa fa-close"></i>
+          <span class="hide">${locale.lbl('core.interface.close')}</span>
+        </a> ${message}
       </div>`
     )
 


### PR DESCRIPTION
The container gives the closing button wrapping div wrong width and height values causing the button to disappear.

Attached a screenshot where the closing button is not visible because of the container class and a screenshot where the button is visible when the container div and class is removed.
![screen shot 2018-12-13 at 09 58 08](https://user-images.githubusercontent.com/40020038/49927586-8695b680-febe-11e8-9f08-d4ac42bb872a.png)
![screen shot 2018-12-13 at 10 03 14](https://user-images.githubusercontent.com/40020038/49927587-8695b680-febe-11e8-89b2-25fa9621dc51.png)

